### PR TITLE
Support for Ecore and transpilation traces (write-only)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,bin,lib,tests
+exclude = .git,__pycache__,bin,lib,pylasu/StrumentaLanguageSupport/*,tests
 max-complexity = 10
 max-line-length = 120
 per-file-ignores = __init__.py:F401

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,5 +39,5 @@ jobs:
         working-directory: tests
       - name: Test with pytest
         run: |
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pyecore
           pytest --cov=pylasu --cov-fail-under=40 tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 pyvenv.cfg
 *.egg-info
 .eggs/
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/
 venv
 build
 dist
+.venv
 pyvenv.cfg
 *.egg-info
 .eggs/

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,1 +1,2 @@
 antlr4-python3-runtime
+pyecore; extra == 'ecore'

--- a/pylasu/StrumentaLanguageSupport/StrumentaLanguageSupport.py
+++ b/pylasu/StrumentaLanguageSupport/StrumentaLanguageSupport.py
@@ -1,0 +1,304 @@
+"""Definition of meta model 'StrumentaLanguageSupport'."""
+from functools import partial
+import pyecore.ecore as Ecore
+from pyecore.ecore import *
+
+
+name = 'StrumentaLanguageSupport'
+nsURI = 'https://strumenta.com/kolasu/v2'
+nsPrefix = ''
+
+eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
+
+eClassifiers = {}
+getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
+IssueType = EEnum('IssueType', literals=['LEXICAL', 'SYNTACTIC', 'SEMANTIC'])
+
+IssueSeverity = EEnum('IssueSeverity', literals=['ERROR', 'WARNING', 'INFO'])
+
+
+BigDecimal = EDataType('BigDecimal', instanceClassName='java.math.BigDecimal')
+
+BigInteger = EDataType('BigInteger', instanceClassName='java.math.BigInteger')
+
+
+class LocalDate(EObject, metaclass=MetaEClass):
+
+    year = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    month = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    dayOfMonth = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, year=None, month=None, dayOfMonth=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if year is not None:
+            self.year = year
+
+        if month is not None:
+            self.month = month
+
+        if dayOfMonth is not None:
+            self.dayOfMonth = dayOfMonth
+
+
+class LocalTime(EObject, metaclass=MetaEClass):
+
+    hour = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    minute = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    second = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    nanosecond = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, hour=None, minute=None, second=None, nanosecond=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if hour is not None:
+            self.hour = hour
+
+        if minute is not None:
+            self.minute = minute
+
+        if second is not None:
+            self.second = second
+
+        if nanosecond is not None:
+            self.nanosecond = nanosecond
+
+
+class LocalDateTime(EObject, metaclass=MetaEClass):
+
+    date = EReference(ordered=True, unique=True, containment=True, derived=False)
+    time = EReference(ordered=True, unique=True, containment=True, derived=False)
+
+    def __init__(self, *, date=None, time=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if date is not None:
+            self.date = date
+
+        if time is not None:
+            self.time = time
+
+
+class Point(EObject, metaclass=MetaEClass):
+
+    line = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+    column = EAttribute(eType=EInt, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, line=None, column=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if line is not None:
+            self.line = line
+
+        if column is not None:
+            self.column = column
+
+
+class Position(EObject, metaclass=MetaEClass):
+
+    start = EReference(ordered=True, unique=True, containment=True, derived=False)
+    end = EReference(ordered=True, unique=True, containment=True, derived=False)
+
+    def __init__(self, *, start=None, end=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if start is not None:
+            self.start = start
+
+        if end is not None:
+            self.end = end
+
+
+@abstract
+class Origin(EObject, metaclass=MetaEClass):
+
+    def __init__(self):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+
+@abstract
+class Destination(EObject, metaclass=MetaEClass):
+
+    def __init__(self):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+
+class Statement(EObject, metaclass=MetaEClass):
+
+    def __init__(self):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+
+class Expression(EObject, metaclass=MetaEClass):
+
+    def __init__(self):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+
+class EntityDeclaration(EObject, metaclass=MetaEClass):
+
+    def __init__(self):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+
+class Issue(EObject, metaclass=MetaEClass):
+
+    type = EAttribute(eType=IssueType, unique=True, derived=False, changeable=True)
+    message = EAttribute(eType=EString, unique=True, derived=False, changeable=True)
+    severity = EAttribute(eType=IssueSeverity, unique=True, derived=False, changeable=True)
+    position = EReference(ordered=True, unique=True, containment=True, derived=False)
+
+    def __init__(self, *, type=None, message=None, severity=None, position=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if type is not None:
+            self.type = type
+
+        if message is not None:
+            self.message = message
+
+        if severity is not None:
+            self.severity = severity
+
+        if position is not None:
+            self.position = position
+
+
+class PossiblyNamed(EObject, metaclass=MetaEClass):
+
+    name = EAttribute(eType=EString, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, name=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if name is not None:
+            self.name = name
+
+
+class ReferenceByName(EObject, metaclass=MetaEClass):
+
+    name = EAttribute(eType=EString, unique=True, derived=False, changeable=True)
+    referenced = EReference(ordered=True, unique=True, containment=False, derived=False)
+
+    def __init__(self, *, name=None, referenced=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if name is not None:
+            self.name = name
+
+        if referenced is not None:
+            self.referenced = referenced
+
+
+class Result(EObject, metaclass=MetaEClass):
+
+    root = EReference(ordered=True, unique=True, containment=True, derived=False)
+    issues = EReference(ordered=True, unique=True, containment=True, derived=False, upper=-1)
+
+    def __init__(self, *, root=None, issues=None):
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
+
+        super().__init__()
+
+        if root is not None:
+            self.root = root
+
+        if issues:
+            self.issues.extend(issues)
+
+
+class NodeDestination(Destination):
+
+    node = EReference(ordered=True, unique=True, containment=False, derived=False)
+
+    def __init__(self, *, node=None, **kwargs):
+
+        super().__init__(**kwargs)
+
+        if node is not None:
+            self.node = node
+
+
+class TextFileDestination(Destination):
+
+    position = EReference(ordered=True, unique=True, containment=True, derived=False)
+
+    def __init__(self, *, position=None, **kwargs):
+
+        super().__init__(**kwargs)
+
+        if position is not None:
+            self.position = position
+
+
+@abstract
+class ASTNode(Origin):
+
+    position = EReference(ordered=True, unique=True, containment=True, derived=False)
+    origin = EReference(ordered=True, unique=True, containment=False, derived=False)
+    destination = EReference(ordered=True, unique=True, containment=True, derived=False)
+
+    def __init__(self, *, position=None, origin=None, destination=None, **kwargs):
+
+        super().__init__(**kwargs)
+
+        if position is not None:
+            self.position = position
+
+        if origin is not None:
+            self.origin = origin
+
+        if destination is not None:
+            self.destination = destination
+
+
+class Named(PossiblyNamed):
+
+    name = EAttribute(eType=EString, unique=True, derived=False, changeable=True)
+
+    def __init__(self, *, name=None, **kwargs):
+
+        super().__init__(**kwargs)
+
+        if name is not None:
+            self.name = name

--- a/pylasu/StrumentaLanguageSupport/__init__.py
+++ b/pylasu/StrumentaLanguageSupport/__init__.py
@@ -25,6 +25,7 @@ ASTNode.origin.eType = Origin
 ASTNode.destination.eType = Destination
 Issue.position.eType = Position
 #  TODO eGenericType not supported ReferenceByName.referenced.eType =
+ReferenceByName.referenced.eType = ASTNode
 #  TODO eGenericType not supported
 Result.root.eType = ASTNode
 Result.issues.eType = Issue

--- a/pylasu/StrumentaLanguageSupport/__init__.py
+++ b/pylasu/StrumentaLanguageSupport/__init__.py
@@ -36,8 +36,5 @@ for classif in otherClassifiers:
     eClassifiers[classif.name] = classif
     classif.ePackage = eClass
 
-for classif in eClassifiers.values():
-    eClass.eClassifiers.append(classif.eClass)
-
 for subpack in eSubpackages:
     eClass.eSubpackages.append(subpack.eClass)

--- a/pylasu/StrumentaLanguageSupport/__init__.py
+++ b/pylasu/StrumentaLanguageSupport/__init__.py
@@ -1,0 +1,42 @@
+
+from .StrumentaLanguageSupport import getEClassifier, eClassifiers
+from .StrumentaLanguageSupport import name, nsURI, nsPrefix, eClass
+from .StrumentaLanguageSupport import BigDecimal, BigInteger, LocalDate, LocalTime, LocalDateTime, Point, Position, Origin, Destination, NodeDestination, TextFileDestination, ASTNode, Statement, Expression, EntityDeclaration, IssueType, IssueSeverity, Issue, PossiblyNamed, Named, ReferenceByName, Result
+
+
+from . import StrumentaLanguageSupport
+
+__all__ = ['BigDecimal', 'BigInteger', 'LocalDate', 'LocalTime', 'LocalDateTime', 'Point', 'Position', 'Origin', 'Destination', 'NodeDestination', 'TextFileDestination',
+           'ASTNode', 'Statement', 'Expression', 'EntityDeclaration', 'IssueType', 'IssueSeverity', 'Issue', 'PossiblyNamed', 'Named', 'ReferenceByName', 'Result']
+
+eSubpackages = []
+eSuperPackage = None
+StrumentaLanguageSupport.eSubpackages = eSubpackages
+StrumentaLanguageSupport.eSuperPackage = eSuperPackage
+
+LocalDateTime.date.eType = LocalDate
+LocalDateTime.time.eType = LocalTime
+Position.start.eType = Point
+Position.end.eType = Point
+NodeDestination.node.eType = ASTNode
+TextFileDestination.position.eType = Position
+ASTNode.position.eType = Position
+ASTNode.origin.eType = Origin
+ASTNode.destination.eType = Destination
+Issue.position.eType = Position
+#  TODO eGenericType not supported ReferenceByName.referenced.eType =
+#  TODO eGenericType not supported
+Result.root.eType = ASTNode
+Result.issues.eType = Issue
+
+otherClassifiers = [BigDecimal, BigInteger, IssueType, IssueSeverity]
+
+for classif in otherClassifiers:
+    eClassifiers[classif.name] = classif
+    classif.ePackage = eClass
+
+for classif in eClassifiers.values():
+    eClass.eClassifiers.append(classif.eClass)
+
+for subpack in eSubpackages:
+    eClass.eSubpackages.append(subpack.eClass)

--- a/pylasu/emf/__init__.py
+++ b/pylasu/emf/__init__.py
@@ -1,2 +1,2 @@
-from .model import *
+from .model import find_eclassifier
 from .metamodel_builder import MetamodelBuilder

--- a/pylasu/emf/__init__.py
+++ b/pylasu/emf/__init__.py
@@ -1,2 +1,2 @@
-from .metamodel_builder import MetamodelBuilder
 from .model import *
+from .metamodel_builder import MetamodelBuilder

--- a/pylasu/emf/__init__.py
+++ b/pylasu/emf/__init__.py
@@ -1,0 +1,2 @@
+from .metamodel_builder import MetamodelBuilder
+from .model import *

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -3,9 +3,9 @@ from dataclasses import is_dataclass, fields
 from enum import Enum, EnumMeta
 from types import resolve_bases
 
-from pyecore.ecore import EAttribute, ECollection, EObject, EPackage, EReference, MetaEClass, EBoolean, EString, EInt, EEnum
+from pyecore.ecore import EAttribute, ECollection, EObject, EPackage, EReference, MetaEClass, EBoolean, EString, EInt, \
+    EEnum
 from pyecore.resources import Resource
-
 from pylasu import StrumentaLanguageSupport as starlasu
 from pylasu.StrumentaLanguageSupport import ASTNode
 from pylasu.emf.model import find_eclassifier
@@ -14,7 +14,8 @@ from pylasu.model.model import InternalField
 
 
 class MetamodelBuilder:
-    def __init__(self, package_name: str, ns_uri: str, ns_prefix: str = None, resource: Resource = None):
+    def __init__(self, package_name: str, ns_uri: str, ns_prefix: str = None, resource: Resource = None,
+                 base_node_class: type = Node):
         self.package = EPackage(package_name, ns_uri, ns_prefix)
         if resource:
             resource.append(self.package)
@@ -23,13 +24,14 @@ class MetamodelBuilder:
             int: EInt,
             str: EString,
         }
+        self.base_node_class = base_node_class
         self.forward_references = []
 
     def can_provide_class(self, cls: type):
         return cls.__module__ == self.package.name
 
     def provide_class(self, cls: type):
-        if cls == Node:
+        if cls == self.base_node_class:
             return ASTNode
         if not self.can_provide_class(cls):
             if self.package.eResource:
@@ -44,7 +46,9 @@ class MetamodelBuilder:
                 "position": EReference("position", starlasu.Position, containment=True)
             }
             for attr in anns if anns else []:
-                if is_dataclass(cls):
+                if attr.startswith('_'):
+                    continue
+                elif is_dataclass(cls):
                     field = next((f for f in fields(cls) if f.name == attr), None)
                     if isinstance(field, InternalField):
                         continue
@@ -52,7 +56,7 @@ class MetamodelBuilder:
                 nmspc[attr] = self.to_structural_feature(attr, attr_type)
             bases = []
             for c in cls.__mro__[1:]:
-                if c == Node:
+                if c == self.base_node_class:
                     bases.append(ASTNode)
                 elif self.can_provide_class(c):
                     bases.append(self.provide_class(c))
@@ -69,7 +73,15 @@ class MetamodelBuilder:
             self.forward_references = [(t, r) for t, r in self.forward_references if not r.eType]
         return eclass
 
-    def to_structural_feature(self, attr, attr_type):
+    def to_structural_feature(self, attr, attr_type, unsupported_type_handler=None):
+        def raise_on_unsupported_type(attr_type, attr):
+            raise Exception("Unsupported type " + str(attr_type) + " for attribute " + attr)
+
+        def default_unsupported_type(_, __):
+            return EObject
+
+        if not unsupported_type_handler:
+            unsupported_type_handler = raise_on_unsupported_type
         if isinstance(attr_type, str):
             resolved = self.package.getEClassifier(attr_type)
             if resolved:
@@ -82,21 +94,24 @@ class MetamodelBuilder:
             return EAttribute(attr, self.data_types[attr_type])
         elif attr_type == object:
             return EAttribute(attr)
-        elif isinstance(attr_type, type) and issubclass(attr_type, Node):
+        elif isinstance(attr_type, type) and issubclass(attr_type, self.base_node_class):
             return EReference(attr, self.provide_class(attr_type), containment=True)
-        elif typing.get_origin(attr_type) == list:
+        elif isinstance(typing.get_origin(attr_type), type) and \
+                issubclass(typing.get_origin(attr_type), typing.Sequence):
             type_args = typing.get_args(attr_type)
             if type_args and len(type_args) == 1:
-                ft = self.to_structural_feature(attr, type_args[0])
+                ft = self.to_structural_feature(attr, type_args[0], default_unsupported_type)
                 ft.upperBound = -1
                 return ft
+        elif typing.get_origin(attr_type) == typing.Union:
+            return EReference(attr, EObject, containment=True)  # TODO here we could refine the type better
         elif isinstance(attr_type, EnumMeta) and issubclass(attr_type, Enum):
             tp = EEnum(name=attr_type.__name__, literals=attr_type.__members__)
             tp.ePackage = self.package
             self.data_types[attr_type] = tp
             return EAttribute(attr, tp)
         else:
-            raise Exception("Unsupported type " + str(attr_type) + " for attribute " + attr)
+            return unsupported_type_handler(attr_type, attr)
 
     def generate(self):
         if self.forward_references:

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -40,6 +40,9 @@ class MetamodelBuilder:
             eclass.eClass.ePackage = self.package
         return eclass
 
+    def generate(self):
+        return self.package
+
 
 def getannotations(cls):
     import inspect

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -62,7 +62,7 @@ def resolve_bases(bases):
         if not isinstance(new_base, tuple):
             raise TypeError("__mro_entries__ must return a tuple")
         else:
-            new_bases[i+shift:i+shift+1] = new_base
+            new_bases[i + shift:i + shift + 1] = new_base
             shift += len(new_base) - 1
     if not updated:
         return bases

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -1,0 +1,52 @@
+from pyecore.ecore import EAttribute, EObject, EPackage, EReference, MetaEClass, EString, EInt
+from pyecore.resources import Resource
+
+from pylasu import StrumentaLanguageSupport as starlasu
+from pylasu.StrumentaLanguageSupport import ASTNode
+from pylasu.model import Node
+
+
+class MetamodelBuilder:
+    def __init__(self, package_name: str, ns_uri: str, ns_prefix: str = None, resource: Resource = None):
+        self.package = EPackage(package_name, ns_uri, ns_prefix)
+        if resource:
+            resource.append(self.package)
+
+    def can_provide_class(self, cls: type):
+        return cls.__module__ == self.package.name
+
+    def provide_class(self, cls: type):
+        if not self.can_provide_class(cls):
+            raise Exception(self.package.name + " cannot provide class " + str(cls))
+        eclass = self.package.getEClassifier(cls.__name__)
+        if not eclass:
+            anns = getannotations(cls)
+            nmspc = {
+                "position": EReference("position", starlasu.Position, containment=True)
+            }
+            for attr in anns:
+                if anns[attr] == str:
+                    nmspc[attr] = EAttribute(attr, EString)
+                elif anns[attr] == int:
+                    nmspc[attr] = EAttribute(attr, EInt)
+            bases = []
+            for c in cls.__mro__[1:]:
+                if c == Node:
+                    bases.append(ASTNode)
+                elif self.can_provide_class(c):
+                    bases.append(self.provide_class(c))
+            bases.append(EObject)
+            eclass = MetaEClass(cls.__name__, tuple(bases), nmspc)
+            eclass.eClass.ePackage = self.package
+        return eclass
+
+
+def getannotations(cls):
+    import inspect
+    try:  # On Python 3.10+
+        return inspect.getannotations(cls)
+    except AttributeError:
+        if isinstance(cls, type):
+            return cls.__dict__.get('__annotations__', None)
+        else:
+            return getattr(cls, '__annotations__', None)

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -1,9 +1,16 @@
-from pyecore.ecore import EAttribute, EObject, EPackage, EReference, MetaEClass, EString, EInt
+import typing
+from dataclasses import is_dataclass, fields
+from enum import Enum, EnumMeta
+from types import resolve_bases
+
+from pyecore.ecore import EAttribute, ECollection, EObject, EPackage, EReference, MetaEClass, EBoolean, EString, EInt, EEnum
 from pyecore.resources import Resource
 
 from pylasu import StrumentaLanguageSupport as starlasu
 from pylasu.StrumentaLanguageSupport import ASTNode
+from pylasu.emf.model import find_eclassifier
 from pylasu.model import Node
+from pylasu.model.model import InternalField
 
 
 class MetamodelBuilder:
@@ -11,12 +18,24 @@ class MetamodelBuilder:
         self.package = EPackage(package_name, ns_uri, ns_prefix)
         if resource:
             resource.append(self.package)
+        self.data_types = {
+            bool: EBoolean,
+            int: EInt,
+            str: EString,
+        }
+        self.forward_references = []
 
     def can_provide_class(self, cls: type):
         return cls.__module__ == self.package.name
 
     def provide_class(self, cls: type):
+        if cls == Node:
+            return ASTNode
         if not self.can_provide_class(cls):
+            if self.package.eResource:
+                eclass = find_eclassifier(self.package.eResource, cls)
+                if eclass:
+                    return eclass
             raise Exception(self.package.name + " cannot provide class " + str(cls))
         eclass = self.package.getEClassifier(cls.__name__)
         if not eclass:
@@ -24,23 +43,65 @@ class MetamodelBuilder:
             nmspc = {
                 "position": EReference("position", starlasu.Position, containment=True)
             }
-            for attr in anns:
-                if anns[attr] == str:
-                    nmspc[attr] = EAttribute(attr, EString)
-                elif anns[attr] == int:
-                    nmspc[attr] = EAttribute(attr, EInt)
+            for attr in anns if anns else []:
+                if is_dataclass(cls):
+                    field = next((f for f in fields(cls) if f.name == attr), None)
+                    if isinstance(field, InternalField):
+                        continue
+                attr_type = anns[attr]
+                nmspc[attr] = self.to_structural_feature(attr, attr_type)
             bases = []
             for c in cls.__mro__[1:]:
                 if c == Node:
                     bases.append(ASTNode)
                 elif self.can_provide_class(c):
                     bases.append(self.provide_class(c))
+                elif self.package.eResource:
+                    esuperclass = find_eclassifier(self.package.eResource, c)
+                    if esuperclass:
+                        bases.append(esuperclass)
             bases.append(EObject)
-            eclass = MetaEClass(cls.__name__, tuple(bases), nmspc)
+            eclass = MetaEClass(cls.__name__, resolve_bases(tuple(bases)), nmspc)
             eclass.eClass.ePackage = self.package
+            for (type_name, ref) in self.forward_references:
+                if type_name == cls.__name__:
+                    ref.eType = eclass
+            self.forward_references = [(t, r) for t, r in self.forward_references if not r.eType]
         return eclass
 
+    def to_structural_feature(self, attr, attr_type):
+        if isinstance(attr_type, str):
+            resolved = self.package.getEClassifier(attr_type)
+            if resolved:
+                return EReference(attr, resolved, containment=True)
+            else:
+                forward_reference = EReference(attr, containment=True)
+                self.forward_references.append((attr_type, forward_reference))
+                return forward_reference
+        elif attr_type in self.data_types:
+            return EAttribute(attr, self.data_types[attr_type])
+        elif attr_type == object:
+            return EAttribute(attr)
+        elif isinstance(attr_type, type) and issubclass(attr_type, Node):
+            return EReference(attr, self.provide_class(attr_type), containment=True)
+        elif typing.get_origin(attr_type) == list:
+            type_args = typing.get_args(attr_type)
+            if type_args and len(type_args) == 1:
+                ft = self.to_structural_feature(attr, type_args[0])
+                ft.upperBound = -1
+                return ft
+        elif isinstance(attr_type, EnumMeta) and issubclass(attr_type, Enum):
+            tp = EEnum(name=attr_type.__name__, literals=attr_type.__members__)
+            tp.ePackage = self.package
+            self.data_types[attr_type] = tp
+            return EAttribute(attr, tp)
+        else:
+            raise Exception("Unsupported type " + str(attr_type) + " for attribute " + attr)
+
     def generate(self):
+        if self.forward_references:
+            raise Exception("The following classes are missing from " + self.package.name + ": " +
+                            ", ".join(n for n, _ in self.forward_references))
         return self.package
 
 
@@ -53,3 +114,15 @@ def getannotations(cls):
             return cls.__dict__.get('__annotations__', None)
         else:
             return getattr(cls, '__annotations__', None)
+
+
+# Monkey patch until fix
+update_opposite = ECollection._update_opposite
+
+
+def update_opposite_if_not_none(self, owner, new_value, remove=False):
+    if owner:
+        update_opposite(self, owner, new_value, remove)
+
+
+ECollection._update_opposite = update_opposite_if_not_none

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -41,30 +41,8 @@ class MetamodelBuilder:
             raise Exception(self.package.name + " cannot provide class " + str(cls))
         eclass = self.package.getEClassifier(cls.__name__)
         if not eclass:
-            anns = getannotations(cls)
-            nmspc = {
-                "position": EReference("position", starlasu.Position, containment=True)
-            }
-            for attr in anns if anns else []:
-                if attr.startswith('_'):
-                    continue
-                elif is_dataclass(cls):
-                    field = next((f for f in fields(cls) if f.name == attr), None)
-                    if isinstance(field, InternalField):
-                        continue
-                attr_type = anns[attr]
-                nmspc[attr] = self.to_structural_feature(attr, attr_type)
-            bases = []
-            for c in cls.__mro__[1:]:
-                if c == self.base_node_class:
-                    bases.append(ASTNode)
-                elif self.can_provide_class(c):
-                    bases.append(self.provide_class(c))
-                elif self.package.eResource:
-                    esuperclass = find_eclassifier(self.package.eResource, c)
-                    if esuperclass:
-                        bases.append(esuperclass)
-            bases.append(EObject)
+            nmspc = self.setup_attributes(cls)
+            bases = self.setup_base_classes(cls)
             eclass = MetaEClass(cls.__name__, resolve_bases(tuple(bases)), nmspc)
             eclass.eClass.ePackage = self.package
             for (type_name, ref) in self.forward_references:
@@ -73,7 +51,37 @@ class MetamodelBuilder:
             self.forward_references = [(t, r) for t, r in self.forward_references if not r.eType]
         return eclass
 
-    def to_structural_feature(self, attr, attr_type, unsupported_type_handler=None):
+    def setup_base_classes(self, cls):
+        bases = []
+        for c in cls.__mro__[1:]:
+            if c == self.base_node_class:
+                bases.append(ASTNode)
+            elif self.can_provide_class(c):
+                bases.append(self.provide_class(c))
+            elif self.package.eResource:
+                esuperclass = find_eclassifier(self.package.eResource, c)
+                if esuperclass:
+                    bases.append(esuperclass)
+        bases.append(EObject)
+        return bases
+
+    def setup_attributes(self, cls):
+        anns = getannotations(cls)
+        nmspc = {
+            "position": EReference("position", starlasu.Position, containment=True)
+        }
+        for attr in anns if anns else []:
+            if attr.startswith('_'):
+                continue
+            elif is_dataclass(cls):
+                field = next((f for f in fields(cls) if f.name == attr), None)
+                if isinstance(field, InternalField):
+                    continue
+            attr_type = anns[attr]
+            nmspc[attr] = self.to_structural_feature(attr, attr_type)
+        return nmspc
+
+    def to_structural_feature(self, attr, attr_type, unsupported_type_handler=None):  # noqa: C901
         def raise_on_unsupported_type(attr_type, attr):
             raise Exception("Unsupported type " + str(attr_type) + " for attribute " + attr)
 
@@ -83,40 +91,60 @@ class MetamodelBuilder:
         if not unsupported_type_handler:
             unsupported_type_handler = raise_on_unsupported_type
         if isinstance(attr_type, str):
-            resolved = self.package.getEClassifier(attr_type)
-            if resolved:
-                return EReference(attr, resolved, containment=True)
-            else:
-                forward_reference = EReference(attr, containment=True)
-                self.forward_references.append((attr_type, forward_reference))
-                return forward_reference
+            return self.to_reference(attr, attr_type)
         elif attr_type in self.data_types:
             return EAttribute(attr, self.data_types[attr_type])
         elif attr_type == object:
             return EAttribute(attr)
-        elif isinstance(attr_type, type) and issubclass(attr_type, self.base_node_class):
+        elif self.is_node_type(attr_type):
             return EReference(attr, self.provide_class(attr_type), containment=True)
-        elif isinstance(typing.get_origin(attr_type), type) and \
-                issubclass(typing.get_origin(attr_type), typing.Sequence):
-            type_args = typing.get_args(attr_type)
-            if type_args and len(type_args) == 1:
-                ft = self.to_structural_feature(attr, type_args[0], default_unsupported_type)
-                ft.upperBound = -1
-                return ft
+        elif self.is_sequence_type(attr_type):
+            return self.to_list_reference(attr, attr_type, default_unsupported_type)
         elif typing.get_origin(attr_type) == typing.Union:
             return EReference(attr, EObject, containment=True)  # TODO here we could refine the type better
-        elif isinstance(attr_type, EnumMeta) and issubclass(attr_type, Enum):
-            tp = EEnum(name=attr_type.__name__, literals=attr_type.__members__)
-            tp.ePackage = self.package
-            self.data_types[attr_type] = tp
-            return EAttribute(attr, tp)
+        elif self.is_enum_type(attr_type):
+            return self.to_enum_attribute(attr, attr_type)
         else:
             return unsupported_type_handler(attr_type, attr)
 
+    def is_enum_type(self, attr_type):
+        return isinstance(attr_type, EnumMeta) and issubclass(attr_type, Enum)
+
+    def is_sequence_type(self, attr_type):
+        return isinstance(typing.get_origin(attr_type), type) and \
+            issubclass(typing.get_origin(attr_type), typing.Sequence)
+
+    def is_node_type(self, attr_type):
+        return isinstance(attr_type, type) and issubclass(attr_type, self.base_node_class)
+
+    def to_enum_attribute(self, attr, attr_type):
+        tp = EEnum(name=attr_type.__name__, literals=attr_type.__members__)
+        tp.ePackage = self.package
+        self.data_types[attr_type] = tp
+        return EAttribute(attr, tp)
+
+    def to_list_reference(self, attr, attr_type, default_unsupported_type):
+        type_args = typing.get_args(attr_type)
+        if type_args and len(type_args) == 1:
+            ft = self.to_structural_feature(attr, type_args[0], default_unsupported_type)
+            ft.upperBound = -1
+            return ft
+        else:
+            raise "Unsupported list type: " + str(attr_type)
+
+    def to_reference(self, attr, attr_type):
+        resolved = self.package.getEClassifier(attr_type)
+        if resolved:
+            return EReference(attr, resolved, containment=True)
+        else:
+            forward_reference = EReference(attr, containment=True)
+            self.forward_references.append((attr_type, forward_reference))
+            return forward_reference
+
     def generate(self):
         if self.forward_references:
-            raise Exception("The following classes are missing from " + self.package.name + ": " +
-                            ", ".join(n for n, _ in self.forward_references))
+            raise Exception("The following classes are missing from " + self.package.name + ": "
+                            + ", ".join(n for n, _ in self.forward_references))
         return self.package
 
 

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -1,8 +1,8 @@
+import types
 import typing
 from collections.abc import Callable
 from dataclasses import is_dataclass, fields
 from enum import Enum, EnumMeta
-from types import resolve_bases
 
 from pyecore.ecore import EAttribute, ECollection, EObject, EPackage, EReference, MetaEClass, EBoolean, EString, EInt, \
     EEnum
@@ -43,6 +43,30 @@ def get_type_arguments(tp):
             res = (list(res[:-1]), res[-1])
         return res
     return ()
+
+
+def resolve_bases(bases):
+    """Resolve MRO entries dynamically as specified by PEP 560."""
+    if hasattr(types, "resolve_bases"):
+        return getattr(types, "resolve_bases")(bases)
+    new_bases = list(bases)
+    updated = False
+    shift = 0
+    for i, base in enumerate(bases):
+        if isinstance(base, type):
+            continue
+        if not hasattr(base, "__mro_entries__"):
+            continue
+        new_base = base.__mro_entries__(bases)
+        updated = True
+        if not isinstance(new_base, tuple):
+            raise TypeError("__mro_entries__ must return a tuple")
+        else:
+            new_bases[i+shift:i+shift+1] = new_base
+            shift += len(new_base) - 1
+    if not updated:
+        return bases
+    return tuple(new_bases)
 
 
 class MetamodelBuilder:

--- a/pylasu/emf/metamodel_builder.py
+++ b/pylasu/emf/metamodel_builder.py
@@ -31,7 +31,7 @@ def is_enum_type(attr_type):
 
 def is_sequence_type(attr_type):
     return isinstance(get_type_origin(attr_type), type) and \
-           issubclass(get_type_origin(attr_type), typing.Sequence)
+        issubclass(get_type_origin(attr_type), typing.Sequence)
 
 
 def get_type_arguments(tp):

--- a/pylasu/emf/model.py
+++ b/pylasu/emf/model.py
@@ -16,9 +16,10 @@ def find_eclass_in_resource(cls: type, resource: Resource):
 def find_eclass(self: Resource, cls: type):
     eclass = find_eclass_in_resource(cls, self)
     if not eclass:
-        for r in (self.resource_set.resources if self.resource_set else []):
-            if r != self:
-                eclass = find_eclass_in_resource(cls, r)
+        for uri in (self.resource_set.resources if self.resource_set else {}):
+            resource = self.resource_set.resources[uri]
+            if resource != self:
+                eclass = find_eclass_in_resource(cls, resource)
                 if eclass:
                     return eclass
     return eclass

--- a/pylasu/emf/model.py
+++ b/pylasu/emf/model.py
@@ -34,7 +34,7 @@ def to_eobject(self: Node, resource: Resource, mappings=None):
     if mappings is None:
         mappings = {}
     elif id(self) in mappings:
-        return mappings[self]
+        return mappings[id(self)]
     eclass = resource.find_eclassifier(type(self))
     if not eclass:
         raise Exception("Unknown classifier for " + str(type(self)))

--- a/pylasu/emf/model.py
+++ b/pylasu/emf/model.py
@@ -1,0 +1,35 @@
+from pyecore.ecore import EPackage
+from pyecore.resources import Resource
+
+from pylasu.model import Node
+from pylasu.support import extension_method
+
+
+def find_eclass_in_resource(cls: type, resource: Resource):
+    pkg_name = cls.__module__
+    for p in resource.contents:
+        if isinstance(p, EPackage) and p.name == pkg_name:
+            return p.getEClassifier(cls.__name__)
+
+
+@extension_method(Resource)
+def find_eclass(self: Resource, cls: type):
+    eclass = find_eclass_in_resource(cls, self)
+    if not eclass:
+        for r in (self.resource_set.resources if self.resource_set else []):
+            if r != self:
+                eclass = find_eclass_in_resource(cls, r)
+                if eclass:
+                    return eclass
+    return eclass
+
+
+@extension_method(Node)
+def to_eobject(self: Node, resource: Resource, mappings=None):
+    if mappings is None:
+        mappings = {}
+    eclass = resource.find_eclass(type(self))
+    if not eclass:
+        raise Exception("Unknown eclass for " + str(type(self)))
+    eobject = eclass()
+    return eobject

--- a/pylasu/model/__init__.py
+++ b/pylasu/model/__init__.py
@@ -1,4 +1,4 @@
-from .model import Node, Origin
+from .model import Node, Origin, internal_field, internal_properties
 from .position import Point, Position, pos
 from .traversing import walk, walk_leaves_first
 from .processing import children

--- a/pylasu/model/model.py
+++ b/pylasu/model/model.py
@@ -1,5 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
+from dataclasses import Field, MISSING
 from typing import Optional, Callable
 
 from .position import Position, Source
@@ -14,6 +15,19 @@ def internal_properties(*props: str):
         cls.__internal_properties__ = [*Node.__internal_properties__, *props]
         return cls
     return decorate
+
+
+class InternalField(Field):
+    pass
+
+
+def internal_field(
+        *, default=MISSING, default_factory=MISSING, init=True, repr=True, hash=None, compare=True, metadata=None):
+    """Return an object to identify internal dataclass fields. The arguments are the same as dataclasses.field."""
+
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError('cannot specify both default and default_factory')
+    return InternalField(default, default_factory, init, repr, hash, compare, metadata)
 
 
 class Origin(ABC):
@@ -32,14 +46,14 @@ class Origin(ABC):
 
 
 def is_internal_property_or_method(value):
-    return isinstance(value, internal_property) or isinstance(value, Callable)
+    return isinstance(value, internal_property) or isinstance(value, InternalField) or isinstance(value, Callable)
 
 
 class Node(Origin):
     origin: Optional[Origin] = None
     parent: Optional["Node"] = None
     position_override: Optional[Position] = None
-    __internal_properties__ = ["origin", "parent", "position"]
+    __internal_properties__ = ["origin", "parent", "position", "position_override"]
 
     def __init__(self, origin: Optional[Origin] = None, parent: Optional["Node"] = None,
                  position_override: Optional[Position] = None):

--- a/pylasu/model/model.py
+++ b/pylasu/model/model.py
@@ -1,4 +1,3 @@
-import ast
 import inspect
 from abc import ABC, abstractmethod
 from typing import Optional, Callable
@@ -36,7 +35,7 @@ def is_internal_property_or_method(value):
     return isinstance(value, internal_property) or isinstance(value, Callable)
 
 
-class Node(Origin, ast.AST):
+class Node(Origin):
     origin: Optional[Origin] = None
     parent: Optional["Node"] = None
     position_override: Optional[Position] = None

--- a/pylasu/parsing/parse_tree.py
+++ b/pylasu/parsing/parse_tree.py
@@ -24,12 +24,7 @@ class ParseTreeOrigin(Origin):
 
     @internal_property
     def source_text(self) -> Optional[str]:
-        if isinstance(self.parse_tree, ParserRuleContext):
-            return self.parse_tree.get_original_text()
-        elif isinstance(self.parse_tree, TerminalNode):
-            return self.parse_tree.getText()
-        else:
-            return None
+        return self.parse_tree.get_original_text()
 
 
 def token_start_point(token: Token):
@@ -64,6 +59,11 @@ def to_position(self: TerminalNode, source: Source = None):
 @extension_method(Token)
 def to_position(self: Token, source: Source = None):
     return Position(self.start_point, self.end_point, source)
+
+
+@extension_method(ParseTree)
+def get_original_text(self: ParseTree) -> str:
+    return self.getText()
 
 
 @extension_method(ParserRuleContext)

--- a/pylasu/playground/__init__.py
+++ b/pylasu/playground/__init__.py
@@ -1,2 +1,2 @@
 from .transpilation_trace import TranspilationTrace
-from .transpilation_trace_ecore import TranspilationTrace as ETranspilationTrace
+from .transpilation_trace_ecore import JsonResource, TranspilationTrace as ETranspilationTrace

--- a/pylasu/playground/__init__.py
+++ b/pylasu/playground/__init__.py
@@ -1,0 +1,2 @@
+from .transpilation_trace import TranspilationTrace
+from .transpilation_trace_ecore import TranspilationTrace as ETranspilationTrace

--- a/pylasu/playground/transpilation_trace.py
+++ b/pylasu/playground/transpilation_trace.py
@@ -5,7 +5,6 @@ from typing import List
 from pyecore.resources import Resource, ResourceSet, URI
 
 from pylasu import StrumentaLanguageSupport as starlasu
-from pylasu.emf.model import to_eobject
 from pylasu.playground.transpilation_trace_ecore import TranspilationTrace as ETranspilationTrace, JsonResource
 from pylasu.validation.validation import Result, Issue
 
@@ -22,8 +21,8 @@ class TranspilationTrace:
         mappings = {}
         return ETranspilationTrace(
             original_code=self.original_code,
-            source_result=starlasu.Result(root=to_eobject(self.source_result.root, resource, mappings)),
-            target_result=starlasu.Result(root=to_eobject(self.target_result.root, resource, mappings)),
+            source_result=starlasu.Result(root=self.source_result.root.to_eobject(resource, mappings)),
+            target_result=starlasu.Result(root=self.target_result.root.to_eobject(resource, mappings)),
             generated_code=self.generated_code
         )
 

--- a/pylasu/playground/transpilation_trace.py
+++ b/pylasu/playground/transpilation_trace.py
@@ -1,0 +1,30 @@
+from pyecore.ecore import *
+
+from pylasu.StrumentaLanguageSupport import Result, Issue
+
+TRANSPILATION_METAMODEL = EPackage(
+    name="StrumentaLanguageSupportTranspilation", nsURI="https://strumenta.com/kolasu/transpilation/v1")
+
+
+class TranspilationTrace(EObject, metaclass=MetaEClass):
+    original_code: EAttribute(name="originalCode", eType=EString)
+    source_result = EReference(name="sourceResult", containment=True, eType=Result)
+    target_result = EReference(name="targetResult", containment=True, eType=Result)
+    generated_code: EAttribute(name="generatedCode", eType=EString)
+    issues = EReference(containment=True, eType=Issue, upper=-1)
+
+    def __init__(self, *, original_code=None, source_result=None, target_result=None, generated_code=None, issues=None):
+        super().__init__()
+        if original_code is not None:
+            self.original_code = original_code
+        if source_result is not None:
+            self.source_result = source_result
+        if target_result is not None:
+            self.target_result = target_result
+        if generated_code is not None:
+            self.generated_code = generated_code
+        if issues:
+            self.issues.extend(issues)
+
+
+TRANSPILATION_METAMODEL.eContents.append(TranspilationTrace)

--- a/pylasu/playground/transpilation_trace.py
+++ b/pylasu/playground/transpilation_trace.py
@@ -1,4 +1,4 @@
-from pyecore.ecore import *
+from pyecore.ecore import EAttribute, EObject, EPackage, EReference, EString, MetaEClass
 
 from pylasu.StrumentaLanguageSupport import Result, Issue
 
@@ -7,10 +7,10 @@ TRANSPILATION_METAMODEL = EPackage(
 
 
 class TranspilationTrace(EObject, metaclass=MetaEClass):
-    original_code: EAttribute(name="originalCode", eType=EString)
+    original_code = EAttribute(name="originalCode", eType=EString)
     source_result = EReference(name="sourceResult", containment=True, eType=Result)
     target_result = EReference(name="targetResult", containment=True, eType=Result)
-    generated_code: EAttribute(name="generatedCode", eType=EString)
+    generated_code = EAttribute(name="generatedCode", eType=EString)
     issues = EReference(containment=True, eType=Issue, upper=-1)
 
     def __init__(self, *, original_code=None, source_result=None, target_result=None, generated_code=None, issues=None):

--- a/pylasu/playground/transpilation_trace_ecore.py
+++ b/pylasu/playground/transpilation_trace_ecore.py
@@ -48,7 +48,7 @@ class TranspilationTrace(EObject, metaclass=MetaEClass):
         resource = rset.create_resource(URI(name))
         for pkg in packages:
             package_resource = rset.create_resource(URI(pkg.nsURI))
-            package_resource.contents.add(pkg)
+            package_resource.contents.append(pkg)
         resource.contents.append(self)
         with BytesIO() as out:
             resource.save(out)

--- a/pylasu/playground/transpilation_trace_ecore.py
+++ b/pylasu/playground/transpilation_trace_ecore.py
@@ -1,0 +1,55 @@
+from io import IOBase, BytesIO
+
+from pyecore.ecore import EObject, MetaEClass, EAttribute, EString, EReference
+from pyecore.resources import ResourceSet, URI
+
+from pyecore.resources.json import JsonResource as BaseJsonResource
+
+from pylasu import StrumentaLanguageSupport as starlasu
+
+nsURI = "https://strumenta.com/kolasu/transpilation/v1"
+name = "StrumentaLanguageSupportTranspilation"
+
+
+class JsonResource(BaseJsonResource):
+
+    def open_out_stream(self, other=None):
+        if isinstance(other, IOBase):
+            return other
+        else:
+            return super().open_out_stream(other)
+
+
+class TranspilationTrace(EObject, metaclass=MetaEClass):
+    # Note: we use camelCase here because Pyecore's JSON serialization doesn't handle having different names for
+    # Python attributes and their corresponding Ecore structural features.
+    originalCode = EAttribute(eType=EString)
+    sourceResult = EReference(containment=True, eType=starlasu.Result)
+    targetResult = EReference(containment=True, eType=starlasu.Result)
+    generatedCode = EAttribute(eType=EString)
+    issues = EReference(containment=True, eType=starlasu.Issue, upper=-1)
+
+    def __init__(self, *, original_code=None, source_result=None, target_result=None, generated_code=None, issues=None):
+        super().__init__()
+        if original_code is not None:
+            self.originalCode = original_code
+        if source_result is not None:
+            self.sourceResult = source_result
+        if target_result is not None:
+            self.targetResult = target_result
+        if generated_code is not None:
+            self.generatedCode = generated_code
+        if issues:
+            self.issues.extend(issues)
+
+    def save_as_json(self, name, *packages):
+        rset = ResourceSet()
+        rset.resource_factory['json'] = JsonResource
+        resource = rset.create_resource(URI(name))
+        for pkg in packages:
+            package_resource = rset.create_resource(URI(pkg.nsURI))
+            package_resource.contents.add(pkg)
+        resource.contents.append(self)
+        with BytesIO() as out:
+            resource.save(out)
+            return out.getvalue().decode('utf-8')

--- a/pylasu/playground/transpilation_trace_ecore.py
+++ b/pylasu/playground/transpilation_trace_ecore.py
@@ -1,9 +1,7 @@
 from io import IOBase, BytesIO
 
-import pyecore.ecore
-from pyecore.ecore import EObject, MetaEClass, EAttribute, EString, EReference, EDataType
+from pyecore.ecore import EObject, MetaEClass, EAttribute, EString, EReference
 from pyecore.resources import ResourceSet, URI
-
 from pyecore.resources.json import JsonResource as BaseJsonResource
 
 from pylasu import StrumentaLanguageSupport as starlasu

--- a/pylasu/playground/transpilation_trace_ecore.py
+++ b/pylasu/playground/transpilation_trace_ecore.py
@@ -1,6 +1,7 @@
 from io import IOBase, BytesIO
 
-from pyecore.ecore import EObject, MetaEClass, EAttribute, EString, EReference
+import pyecore.ecore
+from pyecore.ecore import EObject, MetaEClass, EAttribute, EString, EReference, EDataType
 from pyecore.resources import ResourceSet, URI
 
 from pyecore.resources.json import JsonResource as BaseJsonResource
@@ -18,6 +19,13 @@ class JsonResource(BaseJsonResource):
             return other
         else:
             return super().open_out_stream(other)
+
+    @staticmethod
+    def serialize_eclass(eclass):
+        if eclass.name == "EEnum" and issubclass(eclass, EDataType):
+            return f'{pyecore.ecore.nsURI}#//EEnum'
+        else:
+            return f'{eclass.eRoot().nsURI}{eclass.eURIFragment()}'
 
 
 class TranspilationTrace(EObject, metaclass=MetaEClass):

--- a/pylasu/playground/transpilation_trace_ecore.py
+++ b/pylasu/playground/transpilation_trace_ecore.py
@@ -20,13 +20,6 @@ class JsonResource(BaseJsonResource):
         else:
             return super().open_out_stream(other)
 
-    @staticmethod
-    def serialize_eclass(eclass):
-        if eclass.name == "EEnum" and issubclass(eclass, EDataType):
-            return f'{pyecore.ecore.nsURI}#//EEnum'
-        else:
-            return f'{eclass.eRoot().nsURI}{eclass.eURIFragment()}'
-
 
 class TranspilationTrace(EObject, metaclass=MetaEClass):
     # Note: we use camelCase here because Pyecore's JSON serialization doesn't handle having different names for

--- a/pylasu/validation/validation.py
+++ b/pylasu/validation/validation.py
@@ -1,5 +1,5 @@
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from pylasu.model import Position, Node
@@ -34,4 +34,4 @@ class Issue:
 @dataclass
 class Result:
     root: Node
-    issues: List[Issue]
+    issues: List[Issue] = field(default_factory=list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,14 @@
+[metadata]
+name = Pylasu
+version: 0.2.0
+
 [coverage:run]
 branch = True
 
 [coverage:report]
 show_missing = True
 skip_covered = True
+
+[options.extras_require]
+ecore =
+    pyecore

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 setup(
     name='pylasu',
     packages=find_packages(exclude=["tests"]),
-    version='0.1.0',
+    version='0.2.0',
     description='Pylasu',
     author='Strumenta S.R.L.',
     license='Apache License V2',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,6 +15,11 @@ class Item(Node):
     name: str = None
 
 
+@dataclass
+class ReinforcedBox(Box):
+    strength: int = 10
+
+
 box = Box(
     name="root",
     contents=[

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -43,7 +43,7 @@ class MetamodelBuilderTest(unittest.TestCase):
         resource.append(eClass)
         with BytesIO() as out:
             resource.save(out)
-#            self.assertEqual(out.getvalue().decode("utf-8"), "{}")
+            self.assertEqual(out.getvalue().decode("utf-8"), "{}")
 
     def test_can_serialize_starlasu_model(self):
         starlasu_package = ASTNode.eClass.ePackage

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -18,6 +18,7 @@ nsPrefix = 'test'
 BookCategory = EEnum('BookCategory', literals=['ScienceFiction', 'Biographie', 'Mistery'])
 eClass.eClassifiers.append(BookCategory)
 
+
 @EMetaclass
 class A(object):
     names = EAttribute(eType=EString, upper=-1)
@@ -42,7 +43,7 @@ class MetamodelBuilderTest(unittest.TestCase):
         resource.append(eClass)
         with BytesIO() as out:
             resource.save(out)
-            self.assertEqual(out.getvalue().decode("utf-8"), "{}")
+#            self.assertEqual(out.getvalue().decode("utf-8"), "{}")
 
     def test_can_serialize_starlasu_model(self):
         starlasu_package = ASTNode.eClass.ePackage

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -1,7 +1,7 @@
 import unittest
 from pyecore.ecore import EObject
 
-from pylasu.emf.metamodel_builder import MetamodelBuilder
+from pylasu.emf import MetamodelBuilder
 from tests.fixtures import Box, ReinforcedBox
 
 

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -1,11 +1,25 @@
+import json
 import unittest
-from pyecore.ecore import EObject
+from io import BytesIO
 
+from pyecore.ecore import EObject
+from pyecore.resources import URI
+
+from pylasu.StrumentaLanguageSupport import ASTNode
 from pylasu.emf import MetamodelBuilder
+from pylasu.playground import JsonResource
 from tests.fixtures import Box, ReinforcedBox
 
 
 class MetamodelBuilderTest(unittest.TestCase):
+    def test_can_serialize_starlasu_model(self):
+        starlasu_package = ASTNode.eClass.ePackage
+        resource = JsonResource(URI(starlasu_package.nsURI))
+        resource.contents.append(starlasu_package)
+        with BytesIO() as out:
+            resource.save(out)
+            self.assertEqual(json.loads(out.getvalue().decode('utf-8')), json.loads(STARLASU_MODEL_JSON))
+
     def test_build_metamodel_single_package(self):
         mb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures")
         box = mb.provide_class(Box)
@@ -28,3 +42,582 @@ class MetamodelBuilderTest(unittest.TestCase):
         self.assertIsNotNone(
             next((a for a in box.eClass.eAllAttributes() if a.name == "strength"), None))
         self.assertEqual(2, len(box.eClass.eAllAttributes()))
+
+
+STARLASU_MODEL_JSON = '''{
+  "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EPackage",
+  "eClassifiers": [
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "year",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "month",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "dayOfMonth",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        }
+      ],
+      "name": "LocalDate"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "hour",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "minute",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "second",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "nanosecond",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        }
+      ],
+      "name": "LocalTime"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "date",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//LocalDate"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "time",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//LocalTime"
+          }
+        }
+      ],
+      "name": "LocalDateTime"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "line",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "column",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EInt"
+          }
+        }
+      ],
+      "name": "Point"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "start",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Point"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "end",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Point"
+          }
+        }
+      ],
+      "name": "Position"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "name": "Origin",
+      "abstract": true
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "name": "Destination",
+      "abstract": true
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "name": "Statement"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "name": "Expression"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "name": "EntityDeclaration"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "type",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+            "$ref": "#//IssueType"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "message",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EString"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "severity",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+            "$ref": "#//IssueSeverity"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "position",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Position"
+          }
+        }
+      ],
+      "name": "Issue"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "name",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EString"
+          }
+        }
+      ],
+      "name": "PossiblyNamed"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "name",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EString"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "name": "referenced",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//ASTNode"
+          }
+        }
+      ],
+      "name": "ReferenceByName"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "root",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//ASTNode"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "upperBound": -1,
+          "containment": true,
+          "name": "issues",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Issue"
+          }
+        }
+      ],
+      "name": "Result"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "name": "node",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//ASTNode"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//Destination"
+        }
+      ],
+      "name": "NodeDestination"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "position",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Position"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//Destination"
+        }
+      ],
+      "name": "TextFileDestination"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "position",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Position"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "name": "origin",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Origin"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "containment": true,
+          "name": "destination",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//Destination"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//Origin"
+        }
+      ],
+      "name": "ASTNode",
+      "abstract": true
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "name",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EString"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//PossiblyNamed"
+        }
+      ],
+      "name": "Named"
+    },
+    {
+      "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+      "instanceClassName": "java.math.BigDecimal",
+      "name": "BigDecimal"
+    },
+    {
+      "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+      "instanceClassName": "java.math.BigInteger",
+      "name": "BigInteger"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+      "eLiterals": [
+        "LEXICAL",
+        "SYNTACTIC",
+        "SEMANTIC"
+      ],
+      "name": "IssueType"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+      "eLiterals": [
+        "ERROR",
+        "WARNING",
+        "INFO"
+      ],
+      "name": "IssueSeverity"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "instanceClassName",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EString"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "serializable",
+          "eType": {
+            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "$ref": "#//EBoolean"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//EClassifier"
+        }
+      ],
+      "eOperations": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
+          "eParameters": [
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "self",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "value",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            }
+          ],
+          "name": "from_string"
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
+          "eParameters": [
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "self",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "value",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            }
+          ],
+          "name": "to_string"
+        }
+      ],
+      "name": "EDataType"
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
+          "upperBound": -1,
+          "containment": true,
+          "name": "eLiterals",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+            "$ref": "#//EEnumLiteral"
+          }
+        }
+      ],
+      "eSuperTypes": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+          "$ref": "#//EDataType"
+        }
+      ],
+      "eOperations": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
+          "eParameters": [
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "self",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "notif",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            }
+          ],
+          "name": "notifyChanged"
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
+          "eParameters": [
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "self",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "name",
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "value",
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            }
+          ],
+          "name": "getEEnumLiteral"
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
+          "eParameters": [
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "self",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            },
+            {
+              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
+              "name": "value",
+              "required": true,
+              "eType": {
+                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+                "$ref": "#//ENativeType"
+              }
+            }
+          ],
+          "name": "from_string"
+        }
+      ],
+      "name": "EEnum"
+    }
+  ],
+  "name": "StrumentaLanguageSupport",
+  "nsURI": "https://strumenta.com/kolasu/v2",
+  "nsPrefix": ""
+}'''

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -43,7 +43,46 @@ class MetamodelBuilderTest(unittest.TestCase):
         resource.append(eClass)
         with BytesIO() as out:
             resource.save(out)
-            self.assertEqual(out.getvalue().decode("utf-8"), "{}")
+            self.assertEqual(json.loads(out.getvalue().decode("utf-8")), json.loads('''{
+  "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EPackage",
+  "nsPrefix": "test",
+  "nsURI": "http://test/1.0",
+  "name": "test",
+  "eClassifiers": [
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+      "name": "BookCategory",
+      "eLiterals": [
+        "ScienceFiction",
+        "Biographie",
+        "Mistery"
+      ]
+    },
+    {
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+      "eStructuralFeatures": [
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "upperBound": -1,
+          "name": "names",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
+            "$ref": "#//EString"
+          }
+        },
+        {
+          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
+          "name": "bcat",
+          "eType": {
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
+            "$ref": "#//BookCategory"
+          }
+        }
+      ],
+      "name": "A"
+    }
+  ]
+}'''))
 
     def test_can_serialize_starlasu_model(self):
         starlasu_package = ASTNode.eClass.ePackage
@@ -51,7 +90,10 @@ class MetamodelBuilderTest(unittest.TestCase):
         resource.contents.append(starlasu_package)
         with BytesIO() as out:
             resource.save(out)
-            self.assertEqual(json.loads(out.getvalue().decode('utf-8')), json.loads(STARLASU_MODEL_JSON))
+            starlasu_model = json.loads(STARLASU_MODEL_JSON)
+            serialized_model = json.loads(out.getvalue().decode('utf-8'))
+            self.maxDiff = None
+            self.assertDictEqual(serialized_model, starlasu_model)
 
     def test_build_metamodel_single_package(self):
         mb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures")
@@ -87,7 +129,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "year",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -95,7 +137,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "month",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -103,7 +145,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "dayOfMonth",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         }
@@ -117,7 +159,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "hour",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -125,7 +167,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "minute",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -133,7 +175,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "second",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -141,7 +183,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "nanosecond",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         }
@@ -179,7 +221,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "line",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         },
@@ -187,7 +229,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "column",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EInt"
           }
         }
@@ -255,7 +297,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "message",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EString"
           }
         },
@@ -286,7 +328,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "name",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EString"
           }
         }
@@ -300,7 +342,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "name",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EString"
           }
         },
@@ -427,7 +469,7 @@ STARLASU_MODEL_JSON = '''{
           "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
           "name": "name",
           "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
             "$ref": "#//EString"
           }
         }
@@ -441,12 +483,12 @@ STARLASU_MODEL_JSON = '''{
       "name": "Named"
     },
     {
-      "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
       "instanceClassName": "java.math.BigDecimal",
       "name": "BigDecimal"
     },
     {
-      "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
+      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
       "instanceClassName": "java.math.BigInteger",
       "name": "BigInteger"
     },
@@ -467,187 +509,6 @@ STARLASU_MODEL_JSON = '''{
         "INFO"
       ],
       "name": "IssueSeverity"
-    },
-    {
-      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-      "eStructuralFeatures": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
-          "name": "instanceClassName",
-          "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-            "$ref": "#//EString"
-          }
-        },
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
-          "name": "serializable",
-          "eType": {
-            "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-            "$ref": "#//EBoolean"
-          }
-        }
-      ],
-      "eSuperTypes": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-          "$ref": "#//EClassifier"
-        }
-      ],
-      "eOperations": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
-          "eParameters": [
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "self",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "value",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            }
-          ],
-          "name": "from_string"
-        },
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
-          "eParameters": [
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "self",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "value",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            }
-          ],
-          "name": "to_string"
-        }
-      ],
-      "name": "EDataType"
-    },
-    {
-      "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-      "eStructuralFeatures": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
-          "upperBound": -1,
-          "containment": true,
-          "name": "eLiterals",
-          "eType": {
-            "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-            "$ref": "#//EEnumLiteral"
-          }
-        }
-      ],
-      "eSuperTypes": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-          "$ref": "#//EDataType"
-        }
-      ],
-      "eOperations": [
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
-          "eParameters": [
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "self",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "notif",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            }
-          ],
-          "name": "notifyChanged"
-        },
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
-          "eParameters": [
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "self",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "name",
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "value",
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            }
-          ],
-          "name": "getEEnumLiteral"
-        },
-        {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EOperation",
-          "eParameters": [
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "self",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            },
-            {
-              "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EParameter",
-              "name": "value",
-              "required": true,
-              "eType": {
-                "eClass": "https://strumenta.com/kolasu/v2#//EDataType",
-                "$ref": "#//ENativeType"
-              }
-            }
-          ],
-          "name": "from_string"
-        }
-      ],
-      "name": "EEnum"
     }
   ],
   "name": "StrumentaLanguageSupport",

--- a/tests/test_metamodel_builder.py
+++ b/tests/test_metamodel_builder.py
@@ -1,0 +1,30 @@
+import unittest
+from pyecore.ecore import EObject
+
+from pylasu.emf.metamodel_builder import MetamodelBuilder
+from tests.fixtures import Box, ReinforcedBox
+
+
+class MetamodelBuilderTest(unittest.TestCase):
+    def test_build_metamodel_single_package(self):
+        mb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures")
+        box = mb.provide_class(Box)
+        self.assertIsInstance(box(), EObject)
+        self.assertEqual(box.eClass.ePackage, mb.package)
+        self.assertTrue(box.eClass in mb.package.eContents)
+        self.assertIsNotNone(
+            next((a for a in box.eClass.eAllAttributes() if a.name == "name"), None))
+        self.assertEqual(1, len(box.eClass.eAllAttributes()))
+
+    def test_build_metamodel_single_package_inheritance(self):
+        mb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures")
+        box = mb.provide_class(ReinforcedBox)
+        self.assertIsInstance(box(), EObject)
+        self.assertEqual(box.eClass.ePackage, mb.package)
+        self.assertEqual(2, len(mb.package.eContents))
+        self.assertTrue(box.eClass in mb.package.eContents)
+        self.assertIsNotNone(
+            next((a for a in box.eClass.eAllAttributes() if a.name == "name"), None))
+        self.assertIsNotNone(
+            next((a for a in box.eClass.eAllAttributes() if a.name == "strength"), None))
+        self.assertEqual(2, len(box.eClass.eAllAttributes()))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,7 +79,7 @@ class ModelTest(unittest.TestCase):
         local_symbol = SomeSymbol(name='a', index=0)
         scope = Scope(symbols={'a': [local_symbol]}, parent=Scope(symbols={'a': [SomeSymbol(name='a', index=1)]}))
         result = scope.lookup(symbol_name='a')
-        self.assertEquals(result, local_symbol)
+        self.assertEqual(result, local_symbol)
         self.assertIsInstance(result, Symbol)
 
     def test_scope_lookup_1(self):
@@ -87,7 +87,7 @@ class ModelTest(unittest.TestCase):
         upper_symbol = SomeSymbol(name='a', index=0)
         scope = Scope(symbols={'b': [SomeSymbol(name='b', index=0)]}, parent=Scope(symbols={'a': [upper_symbol]}))
         result = scope.lookup(symbol_name='a')
-        self.assertEquals(result, upper_symbol)
+        self.assertEqual(result, upper_symbol)
         self.assertIsInstance(result, Symbol)
 
     def test_scope_lookup_2(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -106,7 +106,7 @@ class ModelTest(unittest.TestCase):
         upper_symbol = SomeSymbol(name='a', index=0)
         scope = Scope(symbols={'b': [SomeSymbol(name='b', index=0)]}, parent=Scope(symbols={'a': [upper_symbol]}))
         result = scope.lookup(symbol_name='a', symbol_type=SomeSymbol)
-        self.assertEquals(result, upper_symbol)
+        self.assertEqual(result, upper_symbol)
         self.assertIsInstance(result, SomeSymbol)
 
     def test_scope_lookup_5(self):
@@ -114,7 +114,7 @@ class ModelTest(unittest.TestCase):
         upper_symbol = SomeSymbol(name='a', index=0)
         scope = Scope(symbols={'a': [AnotherSymbol(name='a', index=0)]}, parent=Scope(symbols={'a': [upper_symbol]}))
         result = scope.lookup(symbol_name='a', symbol_type=SomeSymbol)
-        self.assertEquals(result, upper_symbol)
+        self.assertEqual(result, upper_symbol)
         self.assertIsInstance(result, SomeSymbol)
 
     def test_scope_lookup_6(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -38,8 +38,8 @@ class ProcessingTest(unittest.TestCase):
         b = BW(a1, [a2, a3])
         b.assign_parents()
         a2.replace_with(a4)
-        self.assertEquals("4", b.many_as[0].s)
-        self.assertEquals(BW(a1, [a4, a3]), b)
+        self.assertEqual("4", b.many_as[0].s)
+        self.assertEqual(BW(a1, [a4, a3]), b)
 
     def test_replace_in_set(self):
         a1 = AW("1")
@@ -56,4 +56,4 @@ class ProcessingTest(unittest.TestCase):
         b = BW(a1, [])
         b.assign_parents()
         a1.replace_with(a2)
-        self.assertEquals("2", b.a.s)
+        self.assertEqual("2", b.a.s)

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -1,4 +1,3 @@
-import dataclasses
 import unittest
 
 import pylasu.StrumentaLanguageSupport as starlasu_metamodel

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -1,9 +1,14 @@
+import json
 import unittest
 
 import pylasu.StrumentaLanguageSupport as starlasu_metamodel
 from pylasu.StrumentaLanguageSupport import ASTNode
 from pylasu.playground.transpilation_trace import TranspilationTrace
 from pyecore.ecore import EString, EAttribute, EInt
+
+
+nsURI = "http://mypackage.com"
+name = "StrumentaLanguageSupportTranspilationTest"
 
 
 class ANode(ASTNode):
@@ -30,10 +35,35 @@ class ModelTest(unittest.TestCase):
                 message="some issue",
                 severity=starlasu_metamodel.IssueSeverity.getEEnumLiteral("WARNING"))]
         )
-        self.assertEqual("a:1", tt.original_code)
-        self.assertEqual("b:2", tt.generated_code)
+        self.assertEqual("a:1", tt.originalCode)
+        self.assertEqual("b:2", tt.generatedCode)
         self.assertEqual("some issue", tt.issues[0].message)
-        self.assertEqual("a", tt.source_result.root.name)
-        self.assertEqual(1, tt.source_result.root.value)
-        self.assertEqual("b", tt.target_result.root.name)
-        self.assertEqual(2, tt.target_result.root.value)
+        self.assertEqual("a", tt.sourceResult.root.name)
+        self.assertEqual(1, tt.sourceResult.root.value)
+        self.assertEqual("b", tt.targetResult.root.name)
+        self.assertEqual(2, tt.targetResult.root.value)
+
+        expected = """{
+  "eClass" : "https://strumenta.com/kolasu/transpilation/v1#//TranspilationTrace",
+  "originalCode" : "a:1",
+  "sourceResult" : {
+    "root" : {
+      "eClass" : "http://mypackage.com#//ANode",
+      "name" : "a",
+      "value" : 1
+    }
+  },
+  "targetResult" : {
+    "root" : {
+      "eClass" : "http://mypackage.com#//ANode",
+      "name" : "b",
+      "value" : 2
+    }
+  },
+  "generatedCode" : "b:2",
+  "issues" : [ {
+    "message" : "some issue",
+    "severity" : "WARNING"
+  } ]
+}"""
+        self.assertEqual(json.loads(expected), json.loads(tt.save_as_json("foo.json")))

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -105,7 +105,7 @@ class ModelTest(unittest.TestCase):
                 }
             },
             "targetResult": { "root": {
-                "eClass": "https://strumenta.com/pylasu/test/fixtures#//Box", 
+                "eClass": "https://strumenta.com/pylasu/test/fixtures#//Box",
                 "name": "A",
                 "contents": []
                 }

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -1,0 +1,40 @@
+import dataclasses
+import unittest
+
+import pylasu.StrumentaLanguageSupport as starlasu_metamodel
+from pylasu.StrumentaLanguageSupport import ASTNode
+from pylasu.playground.transpilation_trace import TranspilationTrace
+from pyecore.ecore import EString, EAttribute, EInt
+
+
+class ANode(ASTNode):
+    name = EAttribute(eType=EString)
+    value = EAttribute(eType=EInt)
+
+    def __init__(self, *, name=None, value=None, **kwargs):
+        super().__init__(**kwargs)
+        if name is not None:
+            self.name = name
+        if value is not None:
+            self.value = value
+
+
+class ModelTest(unittest.TestCase):
+
+    def test_serialize_transpilation_issue(self):
+        tt = TranspilationTrace(
+            original_code="a:1", generated_code="b:2",
+            source_result=starlasu_metamodel.Result(root=ANode(name="a", value=1)),
+            target_result=starlasu_metamodel.Result(root=ANode(name="b", value=2)),
+            issues=[starlasu_metamodel.Issue(
+                type=starlasu_metamodel.IssueType.getEEnumLiteral("TRANSLATION"),
+                message="some issue",
+                severity=starlasu_metamodel.IssueSeverity.getEEnumLiteral("WARNING"))]
+        )
+        self.assertEqual("a:1", tt.original_code)
+        self.assertEqual("b:2", tt.generated_code)
+        self.assertEqual("some issue", tt.issues[0].message)
+        self.assertEqual("a", tt.source_result.root.name)
+        self.assertEqual(1, tt.source_result.root.value)
+        self.assertEqual("b", tt.target_result.root.name)
+        self.assertEqual(2, tt.target_result.root.value)

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -1,15 +1,13 @@
 import json
 import unittest
 
+from pyecore.ecore import EString, EAttribute, EInt
+
 import pylasu.StrumentaLanguageSupport as starlasu
 from pylasu.StrumentaLanguageSupport import ASTNode
 from pylasu.emf.metamodel_builder import MetamodelBuilder
-from pylasu.emf.model import to_eobject
 from pylasu.playground.transpilation_trace import TranspilationTrace
 from pylasu.playground.transpilation_trace_ecore import TranspilationTrace as ETranspilationTrace
-from pyecore.ecore import EString, EAttribute, EInt, MetaEClass
-from pyecore.resources import Resource
-
 from pylasu.validation.validation import Result
 from tests.fixtures import Box
 
@@ -75,14 +73,13 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(json.loads(expected), json.loads(tt.save_as_json("foo.json")))
 
     def test_serialize_transpilation_from_nodes(self):
-        res = Resource()
-        mmb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures", resource=res)
+        mmb = MetamodelBuilder("tests.fixtures", "https://strumenta.com/pylasu/test/fixtures")
         mmb.provide_class(Box)
 
         tt = TranspilationTrace(
             original_code="box(a)[foo, bar]", generated_code='<box name="a"><foo /><bar /></box>',
             source_result=Result(Box("a")),
-            target_result=Result(Box("a"))).to_eobject(res)
+            target_result=Result(Box("a")))
 
         expected = """{
             "eClass": "https://strumenta.com/kolasu/transpilation/v1#//TranspilationTrace",
@@ -91,5 +88,5 @@ class ModelTest(unittest.TestCase):
             "sourceResult": {"root": {"eClass": "https://strumenta.com/pylasu/test/fixtures#//Box"}},
             "targetResult": {"root": {"eClass": "https://strumenta.com/pylasu/test/fixtures#//Box"}}
         }"""
-        as_json = tt.save_as_json("foo.json")
+        as_json = tt.save_as_json("foo.json", mmb.generate())
         self.assertEqual(json.loads(expected), json.loads(as_json))

--- a/tests/test_transpilation_trace.py
+++ b/tests/test_transpilation_trace.py
@@ -5,9 +5,8 @@ from pyecore.ecore import EString, EAttribute, EInt
 
 import pylasu.StrumentaLanguageSupport as starlasu
 from pylasu.StrumentaLanguageSupport import ASTNode
-from pylasu.emf.metamodel_builder import MetamodelBuilder
-from pylasu.playground.transpilation_trace import TranspilationTrace
-from pylasu.playground.transpilation_trace_ecore import TranspilationTrace as ETranspilationTrace
+from pylasu.emf import MetamodelBuilder
+from pylasu.playground import TranspilationTrace, ETranspilationTrace
 from pylasu.validation.validation import Result
 from tests.fixtures import Box
 


### PR DESCRIPTION
With this, we can export transpilation traces from Pylasu using PyEcore.

Rather than rewriting the *Lasu metamodel from scratch, we imported it with pyecoregen from an export made from Kolasu. Unfortunately, pyecoregen is bugged and we have to manually edit the imported metamodel for the time being. When it's patched we may remove the imported metamodel from VCS and download&generate as an automated build step.